### PR TITLE
#159586168 Block user requests on maximum number of people

### DIFF
--- a/app/assets/javascripts/shared_ride_offers.coffee
+++ b/app/assets/javascripts/shared_ride_offers.coffee
@@ -7,20 +7,24 @@ $ ->
     ride_offer_id = $(this).data('ride_offer_id')
 
     $.post("/shared_ride_offers/#{ride_offer_id}", (response, status ,request_object) ->
-     if request_object.status == 201
-      message = 'Interest saved successfully.'
-      $('.modal-body').html(message)
-      location.reload()
-    )
-    .error (response, status, request_object) ->
-      message = 'Something went wrong.'
       $('.modal-body').html(response.message)
+      location.reload()
+    , 'JSON')
+    .fail (response) ->
+      $('.modal-body').html(response.responseJSON.message)
 
   $('.show_interest_ride_offer').click (event) ->
     ride_offer = $(this).data('rideoffer')
     message = "Are you sure you want to take this ride offer from "
     message += "<b>#{ride_offer.origin}</b> to <b>#{ride_offer.destination}</b> "
     message += "at <b>#{ride_offer.take_off.slice(11, 19)}</b>?"
+    interested_counts = $(this).data('interestedcounts')
+
+    if ride_offer.no_of_people == interested_counts
+      message = 'Maximum number of people reached.'
+      $('#rideOfferSignupAlert').modal('show')
+    else
+      $('#show-interest-modal').modal('show')
+      $('#show-interest').data('ride_offer_id', ride_offer.id)
 
     $('.modal-body').html(message)
-    $('#show-interest').data('ride_offer_id', ride_offer.id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+  # Public: Respond with json.
+  #
+  # message - The String representation of the response.
+  # status_code - The Symbol of the status code for the HTTP Resource
+  #
+  # Returns a json response
+  def respond_with_json(message, status_code)
+    respond_to do |format|
+      format.json { render json: { message: message }, status: status_code }
+    end
+  end
 end

--- a/app/controllers/shared_ride_offers_controller.rb
+++ b/app/controllers/shared_ride_offers_controller.rb
@@ -6,6 +6,10 @@ class SharedRideOffersController < ApplicationController
   def index
     @title = 'Shared Ride Offers'
     @ride_offers = RideOffer.shared_ride_offers(current_user)
+
+    @ride_offers.each do |ride_offer|
+      ride_offer.interested_counts = RideOfferInterest.signed_up_counts(ride_offer.id)
+    end
   end
 
   # Get show_interest

--- a/app/controllers/shared_ride_offers_controller.rb
+++ b/app/controllers/shared_ride_offers_controller.rb
@@ -18,8 +18,14 @@ class SharedRideOffersController < ApplicationController
 
     respond_to do |format|
       if @ride_offer
-        @ride_offer.ride_offer_interests.create!(user_id: current_user.id)
-        format.json { render json: {message: 'Ride offer interest saved'}, status: :created }
+        signed_up_counts = RideOfferInterest.signed_up_counts(@ride_offer.id)
+
+        if signed_up_counts == @ride_offer.no_of_people
+          format.json { render json: {message: 'Maximum number of people reached'}, status: :not_acceptable }
+        else
+          @ride_offer.ride_offer_interests.create!(user_id: current_user.id)
+          format.json { render json: {message: 'Ride offer interest saved'}, status: :created }
+        end
       else
         format.json { render json: {message: 'Ride offer not found'}, status: :not_found }
       end

--- a/app/models/ride_offer.rb
+++ b/app/models/ride_offer.rb
@@ -1,4 +1,5 @@
 class RideOffer < ApplicationRecord
+  attr_accessor :interested_counts
   belongs_to :user
   has_many :ride_offer_interests, :dependent => :destroy
 
@@ -8,6 +9,7 @@ class RideOffer < ApplicationRecord
   validates :no_of_people, presence: true, numericality: { only_integer: true, greater_than: 0}
 
   ## Ride shared rides
+  ## Not including the ones created by the current user.
   def self.shared_ride_offers(current_user)
     where.not(user_id: current_user.id)
   end

--- a/app/models/ride_offer_interest.rb
+++ b/app/models/ride_offer_interest.rb
@@ -3,4 +3,11 @@ class RideOfferInterest < ApplicationRecord
   belongs_to :user
 
   validates :ride_offer_id, presence: true
+  validates :user_id, presence: true
+
+
+  ## Return the number of people who have signed up for the ride offer.
+  def self.signed_up_counts(ride_offer_id)
+    where(ride_offer_id: ride_offer_id).count()
+  end
 end

--- a/app/views/shared_ride_offers/index.html.erb
+++ b/app/views/shared_ride_offers/index.html.erb
@@ -23,7 +23,7 @@
           <tr>
           <td><%= "#{ride_offer.interested_counts} / #{ride_offer.no_of_people}" %></td>
             <td>
-              <a href="javascript:undefined" data-rideoffer="<%= ride_offer.to_json %>" class="show_interest_ride_offer" data-toggle="modal" data-target="#show-interest-modal">
+              <a href="javascript:undefined" data-interestedcounts="<%= ride_offer.interested_counts %>" data-rideoffer="<%= ride_offer.to_json %>" class="show_interest_ride_offer">
                 <%= ride_offer.origin %>
               </a>
             </td>
@@ -52,6 +52,26 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
           <button type="button" class="btn btn-primary" id="show-interest">Save changes</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Ride offer signup alert modal -->
+  <div class="modal fade" id="rideOfferSignupAlert" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalCenterTitle">Ride Offer</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          ...
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
         </div>
       </div>
     </div>

--- a/app/views/shared_ride_offers/index.html.erb
+++ b/app/views/shared_ride_offers/index.html.erb
@@ -11,6 +11,7 @@
     <table class="table table-striped" id="table-striped">
       <thead>
         <tr>
+          <th scope="col">Signed Up</th>
           <th scope="col">Origin</th>
           <th scope="col">Destination</th>
           <th scope="col">Take Off</th>
@@ -20,6 +21,7 @@
       <tbody>
         <% @ride_offers.each do |ride_offer| %>
           <tr>
+          <td><%= "#{ride_offer.interested_counts} / #{ride_offer.no_of_people}" %></td>
             <td>
               <a href="javascript:undefined" data-rideoffer="<%= ride_offer.to_json %>" class="show_interest_ride_offer" data-toggle="modal" data-target="#show-interest-modal">
                 <%= ride_offer.origin %>

--- a/spec/controllers/shared_ride_offers_controller_spec.rb
+++ b/spec/controllers/shared_ride_offers_controller_spec.rb
@@ -5,32 +5,40 @@ RSpec.describe SharedRideOffersController, type: :controller do
 
   let(:valid_attributes) {
     {
-      origin: "Origin",
-      destination: "Destination",
+      origin: 'Origin',
+      destination: 'Destination',
       no_of_people: 2,
       take_off: Time.current
     }
   }
 
-  describe "GET #index" do
-    it "returns http success" do
+  describe 'GET #index' do
+    it 'returns http success' do
       get :index
       expect(response).to have_http_status(:success)
       expect(response.body).to match(/Shared Ride Offers/)
     end
   end
 
-  describe "POST #show_interest" do
+  describe 'POST #show_interest' do
     it 'saves interest on existing ride offer' do
       @user.ride_offers.create! valid_attributes
-      post :show_interest, params: { id: 1}, as: :json
+      post :show_interest, params: { id: 1 }, as: :json
       expect(response).to have_http_status(:created)
     end
 
-    it 'doesnot save interest on non existing ride offer' do
+    it 'does not save interest on non existing ride offer' do
       @user.ride_offers.create! valid_attributes
-      post :show_interest, params: { id: 12}, as: :json
+      post :show_interest, params: { id: 12 }, as: :json
       expect(response).to have_http_status(:not_found)
+    end
+
+    it 'does not save when maximum number of people has reached' do
+      create(:ride_offer)
+      create(:ride_offer_interest)
+
+      post :show_interest, params: { id: 1 }, as: :json
+      expect(response).to have_http_status(:not_acceptable)
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :ride_offer_interest do
     id 1
-    ride_offer 1
+    ride_offer_id 1
     user_id 2
   end
 

--- a/spec/models/ride_offer_interest_spec.rb
+++ b/spec/models/ride_offer_interest_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe RideOfferInterest, type: :model do
       ride_offer_interest = RideOfferInterest.create(ride_offer_id: 1, user_id: 2)
       expect(ride_offer_interest).to be_valid
     end
+
+    it 'should return number of counts of people interested in a ride offer' do
+      create(:user)
+      create(:ride_offer)
+      create(:ride_offer_interest)
+      expect(RideOfferInterest.signed_up_counts(1)).to eq 1
+    end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Blocks users from showing interest if the maximum number of people for the ride offer has reached.

#### Description of the task to be completed?
Currently, users can go ahead and show interest in ride offers even when the maximum of people has been gotten. This PR adds the functionality of blocking users from doing so. This PR also adds the functionality of showing the number of people who have shown interest in a ride offer.
 
#### How should this be manually tested?
This can be tested by showing interest in a ride offer.

#### What are the relevant pivotal tracker stories?
[#159586168](https://www.pivotaltracker.com/story/show/159586168)

#### Screenshots
<img width="1176" alt="screen shot 2018-08-22 at 16 58 24" src="https://user-images.githubusercontent.com/11385771/44467872-aa41a200-a62c-11e8-8eca-3fda17d47f58.png">
<img width="736" alt="screen shot 2018-08-22 at 16 58 37" src="https://user-images.githubusercontent.com/11385771/44467873-aada3880-a62c-11e8-99d1-8942a884aab7.png">
