### PR TITLE
#159586076 Remove expired ride offers.

### DIFF
--- a/app/models/ride_offer.rb
+++ b/app/models/ride_offer.rb
@@ -8,9 +8,17 @@ class RideOffer < ApplicationRecord
   validates :take_off, presence: true
   validates :no_of_people, presence: true, numericality: { only_integer: true, greater_than: 0}
 
-  ## Ride shared rides
-  ## Not including the ones created by the current user.
+  # Public: All Ride offers not including those created by the current user.
+  #
+  # current_user - A hash that contains details of the user.
+  #
+  # Return all ride offers not including those created by the current user.
   def self.shared_ride_offers(current_user)
-    where.not(user_id: current_user.id)
+    current_datetime = Time.now
+    where(
+      'take_off >= ? AND created_at >= ?',
+      current_datetime.strftime('%T'),
+      current_datetime.strftime('%F')
+    ).where.not(user_id: current_user.id)
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Removes all expired ride offers
#### Description of the task to be completed?
Currently, all ride offers are shown including those that are expired, this PR removes all the expired ride offers, these are removed depending on the `take_off` time and the `created_at` date
#### How should this be manually tested?
By creating a ride offer that is less than the current time, this will not show under the shared ride offers
#### What are the relevant pivotal tracker stories?
[#159586076](https://www.pivotaltracker.com/story/show/159586076)
#### Screenshots
N/A